### PR TITLE
Task/34 活動タブ：チケットの一番古い履歴が最新のチケットステータスと同じになる問題

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1466,7 +1466,6 @@ class Issue < ActiveRecord::Base
   end
 
   # Retrieves issue's original status from journal if modified since issue creation
-  # TODO: 書けそうだったらissue_test.rbにテスト追加
   def event_status
     changed_statuses = JournalDetail.joins("LEFT OUTER JOIN #{Journal.table_name} ON #{JournalDetail.table_name}.journal_id = #{Journal.table_name}.id").
       where("#{Journal.table_name}.journalized_id = ? AND #{Journal.table_name}.journalized_type = 'Issue' AND #{JournalDetail.table_name}.prop_key = 'status_id'", self.id).

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -47,7 +47,7 @@ class Issue < ActiveRecord::Base
                      :preload => [:project, :status, :tracker],
                      :scope => lambda {|options| options[:open_issues] ? self.open : self.all}
 
-  acts_as_event :title => Proc.new {|o| "#{o.tracker.name} ##{o.id} (#{o.status}): #{o.subject}"},
+  acts_as_event :title => Proc.new {|o| "#{o.tracker.name} ##{o.id} (#{o.event_status}): #{o.subject}"},
                 :url => Proc.new {|o| {:controller => 'issues', :action => 'show', :id => o.id}},
                 :type => Proc.new {|o| 'issue' + (o.closed? ? '-closed' : '')}
 
@@ -1463,6 +1463,17 @@ class Issue < ActiveRecord::Base
       s << ' assigned-to-my-group' if user.groups.any? {|g| g.id == assigned_to_id}
     end
     s
+  end
+
+  # Retrieves issue's original status from journal if modified since issue creation
+  # TODO: 書けそうだったらissue_test.rbにテスト追加
+  def event_status
+    changed_statuses = JournalDetail.joins("LEFT OUTER JOIN #{Journal.table_name} ON #{JournalDetail.table_name}.journal_id = #{Journal.table_name}.id").
+      where("#{Journal.table_name}.journalized_id = ? AND #{Journal.table_name}.journalized_type = 'Issue' AND #{JournalDetail.table_name}.prop_key = 'status_id'", self.id).
+      order("#{Journal.table_name}.created_on")
+
+    initial_status_id = changed_statuses.first.try(:old_value)
+    initial_status_id ? IssueStatus.find_by_id(initial_status_id.to_i) : self.status
   end
 
   # Unassigns issues from +version+ if it's no longer shared with issue's project

--- a/test/unit/activity_test.rb
+++ b/test/unit/activity_test.rb
@@ -132,6 +132,24 @@ class ActivityTest < ActiveSupport::TestCase
     assert_equal content.page, content.event_group
   end
 
+  def test_activity_contains_issue_status_update_events
+    issue = Issue.generate!(:status_id => 1)
+    issue.init_journal(User.first, "Change Status")
+    issue.status_id = 2
+    assert issue.save
+
+    events = find_events(User.anonymous, :project => @project)
+    target_issue_events = events.find_all { |event| event == issue || (event.is_a?(Journal) && event.issue == issue ) }
+    target_issue_events.sort! { |x, y| x.event_datetime <=> y.event_datetime }
+
+    event_titles = target_issue_events.map{ |e| e.event_title }
+    assert_equal("Bug ##{issue.id} (New): Generated", event_titles[0], "event title should includes (New)")
+    assert_equal("Bug ##{issue.id} (Assigned): Generated", event_titles[1], "event title should includes (Assinged)")
+  end
+
+  # TODO: test when no journal
+  # TODO: test when three or more journal
+
   class TestActivityProviderWithPermission
     def self.activity_provider_options
       {'test' => {:permission => :custom_permission}}


### PR DESCRIPTION
- [x] activity_testで問題を再現するテストを追加
- [x] 問題を修正
- [x] Issue#event_statusのテストを追加
- [x] activity_testでケースを増やす