### PR TITLE
task/27 プロジェクトの概要画面で公開範囲がわかるようにする www.redmine.org#35044

### DIFF
--- a/app/views/projects/_members_box.html.erb
+++ b/app/views/projects/_members_box.html.erb
@@ -4,5 +4,12 @@
     <% @principals_by_role.keys.sort.each do |role| %>
       <p><span class="label"><%= role %>:</span> <%= @principals_by_role[role].sort.collect{|p| link_to_principal(p, :class => p.is_a?(Group) ? 'icon icon-group' : nil)}.join(", ").html_safe %></p>
     <% end %>
+    <% if @project.is_public %>
+      <hr>
+      <div id="is-public-project-notice">
+        <p span class="label"><%= l(:field_is_public) %>:</span> <%= l(:general_text_Yes) %>
+        <em class="info"><%= Setting.login_required? ? l(:text_project_is_public_non_member) : l(:text_project_is_public_anonymous) %></em>
+      </div>
+    <% end -%>
   </div>
   <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -21,7 +21,7 @@
   <% end %>
 </div>
 
-<h2><%=l(:label_overview)%></h2>
+<h2><%=l(:label_overview)%> <% if @project.is_public %><span class="badge badge-project-public"><%= l(:label_public_projects) %></span><% end %></h2>
 
 <% unless @project.active? %>
   <p class="warning"><span class="icon icon-lock"><%= l(:text_project_closed) %></span></p>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -21,7 +21,7 @@
   <% end %>
 </div>
 
-<h2><%=l(:label_overview)%> <% if @project.is_public %><span class="badge badge-project-public"><%= l(:label_public_projects) %></span><% end %></h2>
+<h2><%=l(:label_overview)%> <% if @project.is_public %><span class="badge badge-project-public"><%= l(:field_is_public) %></span><% end %></h2>
 
 <% unless @project.active? %>
   <p class="warning"><span class="icon icon-lock"><%= l(:text_project_closed) %></span></p>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1467,6 +1467,10 @@ td.gantt_selected_column .gantt_hdr,.gantt_selected_column_container {
   color: #fff;
   border: 1px solid #d22;
 }
+.badge-project-public {
+  color: #d22;
+  border: 1px solid #d22;
+}
 .badge-count {
   color: #fff;
   background:#9DB9D5;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1468,8 +1468,8 @@ td.gantt_selected_column .gantt_hdr,.gantt_selected_column_container {
   border: 1px solid #d22;
 }
 .badge-project-public {
-  color: #d22;
-  border: 1px solid #d22;
+  color: #205D86;
+  border: 1px solid #205D86;
 }
 .badge-count {
   color: #fff;

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -729,7 +729,7 @@ class ProjectsControllerTest < Redmine::ControllerTest
 
     get(:show, params: {id: p.identifier})
     assert_response :success
-    assert_select '.badge.badge-project-public', text: l(:label_public_projects)
+    assert_select '.badge.badge-project-public', text: l(:field_is_public)
   end
 
   def test_show_should_not_display_project_public_badge_if_project_is_private

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -723,6 +723,25 @@ class ProjectsControllerTest < Redmine::ControllerTest
     assert_select '#is-public-project-notice', :count => 0
   end
 
+  def test_show_should_display_project_public_badge_if_project_is_public
+    p = Project.find('ecookbook')
+    assert p.is_public?
+
+    get(:show, params: {id: p.identifier})
+    assert_response :success
+    assert_select '.badge.badge-project-public', text: l(:label_public_projects)
+  end
+
+  def test_show_should_not_display_project_public_badge_if_project_is_private
+    @request.session[:user_id] = 1
+    p = Project.find('private-child')
+    assert_not p.is_public?
+
+    get(:show, params: {id: p.identifier})
+    assert_response :success
+    assert_select '.badge.badge-project-public', count: 0
+  end
+
   def test_show_should_display_visible_custom_fields
     ProjectCustomField.find_by_name('Development status').update_attribute :visible, true
     get(:show, :params => {:id => 'ecookbook'})


### PR DESCRIPTION
redmine.orgのチケットURL:
 - https://www.redmine.org/issues/35044
 - Show notice on project's overview page when the project is public

TODO:
- [x] 単体テストかく
- [ ] ...
