### PR TITLE
[WIP] Task/30-2 デフォルトで新しいプロジェクトは公開にするをデフォルトオフにする

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -55,8 +55,11 @@ class AdminController < ApplicationController
   # (roles, trackers, statuses, workflow, enumerations)
   def default_configuration
     if request.post?
+      options = {}
+      options[:default_projects_public] = params[:default_projects_public].presence || 'private'
+      
       begin
-        Redmine::DefaultData::Loader::load(params[:lang])
+        Redmine::DefaultData::Loader::load(params[:lang], options)
         flash[:notice] = l(:notice_default_data_loaded)
       rescue => e
         flash[:error] = l(:error_can_t_load_default_data, ERB::Util.h(e.message))

--- a/app/views/admin/_no_data.html.erb
+++ b/app/views/admin/_no_data.html.erb
@@ -2,7 +2,8 @@
 <%= form_tag({:action => 'default_configuration'}) do %>
     <%= simple_format(l(:text_no_configuration_data)) %>
     <p><%= l(:field_language) %>:
-    <%= select_tag 'lang', options_for_select(lang_options_for_select(false), current_language.to_s) %>
+    <%= select_tag 'lang', options_for_select(lang_options_for_select(false), current_language.to_s) %><br/>
+    <label class="inline"><%= check_box_tag :default_projects_public, 'public', true %> <%= l(:setting_default_projects_public) %></label><br/>
     <%= submit_tag l(:text_load_default_configuration) %></p>
 <% end %>
 </div>

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -166,6 +166,10 @@ module Redmine
               support.id.to_s
             ]
 
+            # set new project as private
+            # もし環境変数 が private だったら
+            Setting.default_projects_public = 0
+
             if workflow
               # Workflow
               Tracker.all.each do |t|

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -166,9 +166,10 @@ module Redmine
               support.id.to_s
             ]
 
-            # set new project as private
-            # もし環境変数 が private だったら
-            Setting.default_projects_public = 0
+            # set new project as private if default_projects_public option is exist
+            if options[:default_projects_public] == 'private' 
+              Setting.default_projects_public = 0
+            end
 
             if workflow
               # Workflow

--- a/lib/tasks/load_default_data.rake
+++ b/lib/tasks/load_default_data.rake
@@ -22,8 +22,11 @@ namespace :redmine do
       puts "===================================="
     end
 
+    options = {}
+    options[:default_projects_public] = ENV['REDMINE_DEFAULT_PROJECTS_PUBLIC'].presence
+  
     begin
-      Redmine::DefaultData::Loader.load(current_language)
+      Redmine::DefaultData::Loader.load(current_language, options)
       puts "Default configuration data loaded."
     rescue Redmine::DefaultData::DataAlreadyLoaded => error
       puts error.message


### PR DESCRIPTION
redmine.orgのチケットURL: https://www.redmine.org/issues/xxxx
[scrapbox:第11回/Redmineインストール直後のデフォルトデータを改善する](https://scrapbox.io/redmine-patch/%E7%AC%AC11%E5%9B%9E%2FRedmine%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E7%9B%B4%E5%BE%8C%E3%81%AE%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92%E6%94%B9%E5%96%84%E3%81%99%E3%82%8B_%2330)

TODO:
- [x] REDMINE_SETTING=private bin/rake db:load_default_data するために `ENV['REDMINE_SETTING']` を取得して load(current_language, {REDMINE_SETTING:} で渡すように変更する
- [x] load_default_data してなかったときに admin を開いた画面で REDMINE_SETTING: private なチェックボックスをつくる
- [x] チェックボックスよみとって load() に渡すように修正する
- [x] load で受け取って # Setting.default_projects_public = 0
- [ ] テストをかく
- [ ] Redmine.org に チケットを作る
