### PR TITLE
Remove 2.5 support, add 3.0 and 3.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.6, 2.7, 3.0, 3.1]
         db_version: [5.7]
     runs-on: ubuntu-latest
     container:
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.6, 2.7, 3.0, 3.1]
         db_version: [10]
     runs-on: ubuntu-latest
     container:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.6, 2.7, 3.0, 3.1]
     runs-on: ubuntu-latest
     container:
       image: ruby:${{ matrix.ruby }}


### PR DESCRIPTION
CIでRuby 2.5 のテストがこけているようでした。
https://github.com/redmine-patch-meetup/redmine-dev-mirror/runs/6843257002?check_suite_focus=true
```
Run ./.github/actions/test-with-db.sh mysql
+ database=mysql
+ cp ./config/database.mysql.yml ./config/database.yml
+ bundle install --path vendor/bundle --without minimagick
Your Ruby version is 2.5.9, but your Gemfile specified >= 2.[6](https://github.com/redmine-patch-meetup/redmine-dev-mirror/runs/6843257002?check_suite_focus=true#step:5:7).0, < 3.2.0
+ bundle update
Your Ruby version is 2.5.9, but your Gemfile specified >= 2.6.0, < 3.2.0
+ bundle exec rake db:create db:migrate
Bundler::RubyVersionMismatch: Your Ruby version is 2.5.9, but your Gemfile specified >= 2.6.0, < 3.2.0
bundler: failed to load command: rake (/usr/local/bin/rake)
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/definition.rb:495:in `validate_ruby!'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/definition.rb:4[7](https://github.com/redmine-patch-meetup/redmine-dev-mirror/runs/6843257002?check_suite_focus=true#step:5:8)0:in `validate_runtime!'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:101:in `setup'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/setup.rb:20:in `<top (required)>'
  /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
+ bundle exec rake test
Bundler::RubyVersionMismatch: Your Ruby version is 2.5.[9](https://github.com/redmine-patch-meetup/redmine-dev-mirror/runs/6843257002?check_suite_focus=true#step:5:10), but your Gemfile specified >= 2.6.0, < 3.2.0
bundler: failed to load command: rake (/usr/local/bin/rake)
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/definition.rb:495:in `validate_ruby!'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/definition.rb:470:in `validate_runtime!'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler.rb:[10](https://github.com/redmine-patch-meetup/redmine-dev-mirror/runs/6843257002?check_suite_focus=true#step:5:11)1:in `setup'
  /usr/local/lib/ruby/site_ruby/2.5.0/bundler/setup.rb:20:in `<top (required)>'
  /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
Error: Process completed with exit code 1.
```

調べてみたところ、どうも先月末にRuby 2.5をドロップすることになったようでしたので、
- [Patch #37159: Drop Ruby 2.5 support - Redmine](https://www.redmine.org/issues/37159)

CIのMatrixからRuby 2.5を削除し、Ruby 3.0/3.1 を追加してみました。