### PR TITLE
システムテスト関連のGemをアップグレードして、ruby3.0 以降でも動くようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,8 +101,8 @@ group :test do
   # For running system tests
   gem 'puma'
   gem 'capybara', '~> 3.36.0'
-  gem "selenium-webdriver", "~> 3.142.7"
-  gem 'webdrivers', '4.6.1', require: false
+  gem "selenium-webdriver", Gem.ruby_version < Gem::Version.new('2.7') ? "4.1.0" : "~> 4.3.0"
+  gem 'webdrivers', '~> 5.0.0', require: false
   # RuboCop
   gem 'rubocop', '~> 1.32.0'
   gem 'rubocop-performance', '~> 1.14.2'

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -442,8 +442,11 @@ class IssuesSystemTest < ApplicationSystemTestCase
     # wait for ajax response
     assert page.has_select?('issue_project_id', selected: 'OnlineStore')
 
-    submit_buttons = page.all('input[type=submit]')
-    assert_equal 2, submit_buttons.size
+    submit_buttons = []
+    finally do
+      submit_buttons = page.all('input[type=submit]')
+      assert_equal 2, submit_buttons.size
+    end
     assert_equal 'Move', submit_buttons[0].value
     assert_equal 'Move and follow', submit_buttons[1].value
 
@@ -506,8 +509,11 @@ class IssuesSystemTest < ApplicationSystemTestCase
     # wait for ajax response
     assert page.has_select?('issue_project_id', selected: 'OnlineStore')
 
-    submit_buttons = page.all('input[type=submit]')
-    assert_equal 2, submit_buttons.size
+    submit_buttons = []
+    finally do
+      submit_buttons = page.all('input[type=submit]')
+      assert_equal 2, submit_buttons.size
+    end
     assert_equal 'Copy', submit_buttons[0].value
     assert_equal 'Copy and follow', submit_buttons[1].value
     page.find('#issue_priority_id').select('High')

--- a/test/system/timelog_test.rb
+++ b/test/system/timelog_test.rb
@@ -41,9 +41,11 @@ class TimelogTest < ApplicationSystemTestCase
     within 'form#new_time_entry' do
       select 'eCookbook', :from => 'Project'
     end
-    within 'select#time_entry_activity_id' do
-      assert has_content?('Development')
-      assert !has_content?('Design')
+    finally do
+      within 'select#time_entry_activity_id' do
+        assert has_content?('Development')
+        assert !has_content?('Design')
+      end
     end
   end
 


### PR DESCRIPTION
現状、Redmine のシステムテストは、ruby3 以降では動きません( [モンキーパッチ](https://github.com/SeleniumHQ/selenium/issues/9001) をあてれば動く)。
これは、seleniumのバージョンが古いためです。

Selenium4 は登場してから結構経っているし、関連gemは ruby2.6 でも動くようなのでアップグレードのパッチを書きました。

あわせて、環境変数`SELENIUM_REMOTE_URL`等が設定してあれば、README のパッチをあてなくてもリモートからのシステムテストができるようにしてみました。
これ、本来、 [#34269](https://www.redmine.org/issues/34269) で対応されている想定だと思うんですが、一部修正が必要なようです(以前は、現在のコードで動いていた可能性もありますが、そこまで追ってません)。