### PR TITLE
第26・27回 カスタムフィールドを含むチケットのフィルタの結果に一貫性がない。

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1426,8 +1426,8 @@ class Query < ActiveRecord::Base
     when "~"
       sql = sql_contains("#{db_table}.#{db_field}", value.first)
     when "!~"
-      sql = "#{db_table}.#{db_field} IS NULL"
-      sql += " OR " + sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
+      sql = sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
+      sql += " OR #{db_table}.#{db_field} IS NULL" if is_custom_filter
     when "^"
       sql = sql_contains("#{db_table}.#{db_field}", value.first, :starts_with => true)
     when "$"

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1426,8 +1426,6 @@ class Query < ActiveRecord::Base
     when "~"
       sql = sql_contains("#{db_table}.#{db_field}", value.first)
     when "!~"
-      # binding.pry
-      # sql = sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
       sql = "#{db_table}.#{db_field} IS NULL"
       sql += " OR " + sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
     when "^"

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1426,7 +1426,10 @@ class Query < ActiveRecord::Base
     when "~"
       sql = sql_contains("#{db_table}.#{db_field}", value.first)
     when "!~"
-      sql = sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
+      # binding.pry
+      # sql = sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
+      sql = "#{db_table}.#{db_field} IS NULL"
+      sql += " OR " + sql_contains("#{db_table}.#{db_field}", value.first, :match => false)
     when "^"
       sql = sql_contains("#{db_table}.#{db_field}", value.first, :starts_with => true)
     when "$"

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -143,6 +143,7 @@ class QueryTest < ActiveSupport::TestCase
 
   def find_issues_with_query(query)
     Issue.joins(:status, :tracker, :project, :priority).
+    # Issue.joins(:status, :tracker, :project, :priority, :custom_values).
       where(query.statement).to_a
   end
 
@@ -708,6 +709,16 @@ class QueryTest < ActiveSupport::TestCase
     query.add_filter('subject', '!~', ['cdeF'])
     result = find_issues_with_query(query)
     assert_not_include issue, result
+  end
+
+  def test_operator_does_not_contain_on_text_custom_field
+    query = IssueQuery.new(:name => '_')
+    # query.add_filter('cf_2', '!~', ['125'])
+    query.add_filter('cf_2', '!*', [])
+    # query.filters = {"cf_2" => {:operator => '!*', :values => []}}
+    binding.pry
+    result = find_issues_with_query(query)
+    assert_equal 10, result.size
   end
 
   def test_range_for_this_week_with_week_starting_on_monday

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -143,7 +143,6 @@ class QueryTest < ActiveSupport::TestCase
 
   def find_issues_with_query(query)
     Issue.joins(:status, :tracker, :project, :priority).
-    # Issue.joins(:status, :tracker, :project, :priority, :custom_values).
       where(query.statement).to_a
   end
 
@@ -713,12 +712,11 @@ class QueryTest < ActiveSupport::TestCase
 
   def test_operator_does_not_contain_on_text_custom_field
     query = IssueQuery.new(:name => '_')
-    # query.add_filter('cf_2', '!~', ['125'])
-    query.add_filter('cf_2', '!*', [])
-    # query.filters = {"cf_2" => {:operator => '!*', :values => []}}
-    binding.pry
+    query.filters = {"cf_2" => {:operator => '!~', :values => ['125']}}
     result = find_issues_with_query(query)
-    assert_equal 10, result.size
+    # "cf_2" (Searchable field) custom field's available trackers are only 1:Bug and 3:Support request.
+    # 8(Issue.visible.where(tracker: [1,3])) - 2(contain "125") = 6(not contain "125")
+    assert_equal 6, result.size
   end
 
   def test_range_for_this_week_with_week_starting_on_monday


### PR DESCRIPTION
(Scrapboxから加藤さん記載内容を転記しています)

## 再現手順

1. 動作確認環境を用意する
   ```
   $ RAILS_ENV=development bin/rails db:fixtures:load
   ```
2. Redmine を起動し、http://localhost:3000/issues を表示する。
    "Add filter" で "Tracker" を選択し、Searchable fieldカスタムフィールドが
    利用可能なトラッカー(Bug・Support request)を "is" で含めて検索し、
    チケットが8件であることを確認する 
3. さらに "Add filter" で "Searchable field" を選択し、条件で "contains" を選択し125を入力する
    結果が2件となる
 
4. 条件を "doesn't contain" に変更し適用する
    結果が1件となる。
 
3,4 の件数の合計が3件となりチケットの総数6件と一致しない

## 期待する挙動

"contains" の結果と "doesn't contain"の結果の和がチケットの総数と合致する。
条件を "any" と "none" とした場合は結果の和とチケットの総数が合致する。

## 考えられる原因

"doesn't contain" の場合に カスタムフィールド "Searchable filter" が存在していないチケットが無視されている

## 対応

挙動を “any”, “none” とそろえるために、”doesn’t contain” の結果に、カスタムフィールドを持たないチケットの件数を含めるべきではないでしょうか。