### PR TITLE
Update test.yml matrix ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: ['2.7', '3.0', '3.1', '3.2']
         db_version: [5.7]
     runs-on: ubuntu-latest
     container:
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: ['2.7', '3.0', '3.1', '3.2']
         db_version: [10]
     runs-on: ubuntu-latest
     container:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     runs-on: ubuntu-latest
     container:
       image: ruby:${{ matrix.ruby }}


### PR DESCRIPTION
redmine.orgのチケットURL: [Feature #38134: Drop Ruby 2.6 support - Redmine](https://www.redmine.org/issues/38134)

### 対応内容

- RedmineのトランクでRuby 2.6がドロップされたので、マトリックスから削除しました。
  - [Feature #38134: Drop Ruby 2.6 support - Redmine](https://www.redmine.org/issues/38134)
- RedmineのトランクでRuby 3.2に対応したようなので、合わせて対応しました。
  - [Feature #38099: Ruby 3.2 support - Redmine](https://www.redmine.org/issues/38099)
- ※ YAMLで `3.0` が `3` と見なされてしまうため、シングルクォートで囲むようにしました。
  - 参考リンク: https://github.com/gtt-project/redmine_gtt/issues/205

### 確認内容

- [x] CI(Test)のマトリックスが全てパスすることを確認する
  - https://github.com/redmine-patch-meetup/redmine-dev-mirror/actions/runs/4030398788
