### PR TITLE
フィルターで複数の親チケットを検索できるが、関連チケットも複数で検索できるようにしたい

### DIFF
--- a/app/models/issue_query.rb
+++ b/app/models/issue_query.rb
@@ -723,6 +723,7 @@ class IssueQuery < Query
       relation_type = relation_options[:reverse] || relation_type
       join_column, target_join_column = target_join_column, join_column
     end
+    ids = value.first.to_s.scan(/\d+/).map(&:to_i).uniq
     sql =
       case operator
       when "*", "!*"
@@ -739,7 +740,7 @@ class IssueQuery < Query
            " FROM #{IssueRelation.table_name}" \
              " WHERE #{IssueRelation.table_name}.relation_type =" \
                   " '#{self.class.connection.quote_string(relation_type)}'" \
-               " AND #{IssueRelation.table_name}.#{target_join_column} = #{value.first.to_i})"
+               " AND #{IssueRelation.table_name}.#{target_join_column} IN (#{ids.join(",")}))"
       when "=p", "=!p", "!p"
         op = (operator == "!p" ? 'NOT IN' : 'IN')
         comp = (operator == "=!p" ? '<>' : '=')

--- a/test/unit/query_test.rb
+++ b/test/unit/query_test.rb
@@ -1338,8 +1338,16 @@ class QueryTest < ActiveSupport::TestCase
     assert_equal [1], find_issues_with_query(query).map(&:id).sort
 
     query = IssueQuery.new(:name => '_')
+    query.filters = {"relates" => {:operator => '=', :values => ['1,2']}}
+    assert_equal [1, 2, 3], find_issues_with_query(query).map(&:id).sort
+
+    query = IssueQuery.new(:name => '_')
     query.filters = {"relates" => {:operator => '!', :values => ['1']}}
     assert_equal Issue.where.not(:id => [2, 3]).order(:id).ids, find_issues_with_query(query).map(&:id).sort
+
+    query = IssueQuery.new(:name => '_')
+    query.filters = {"relates" => {:operator => '!', :values => ['1,2']}}
+    assert_equal Issue.where.not(:id => [1, 2, 3]).order(:id).ids, find_issues_with_query(query).map(&:id).sort
   end
 
   def test_filter_on_relations_with_any_issues_in_a_project


### PR DESCRIPTION
redmine.orgのチケットURL: https://www.redmine.org/issues/38301

TODO:
- [x] 単体テストかく
- [x] 本家パッチ投稿
