### PR TITLE
Redmine plugin の gem化 #81

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 /.bundle
 /Gemfile.lock
 /Gemfile.local
+/Gemfile.extension
 
 /node_modules
 yarn-error.log

--- a/Gemfile
+++ b/Gemfile
@@ -121,3 +121,10 @@ end
 Dir.glob File.expand_path("../plugins/*/{Gemfile,PluginGemfile}", __FILE__) do |file|
   eval_gemfile file
 end
+
+extension_gemfile = File.join(File.dirname(__FILE__), "Gemfile.extension")
+if File.exist?(extension_gemfile)
+  group :redmine_extension do
+    eval_gemfile extension_gemfile
+  end
+end

--- a/Gemfile.extension.example
+++ b/Gemfile.extension.example
@@ -1,0 +1,5 @@
+# vim: set ft=ruby
+# Copy this file to Gemfile.extension and add any rubygem plugins
+
+# Example:
+#   gem 'redmine_sample_plugin', '~> 1.1.0'

--- a/app/views/admin/plugins.html.erb
+++ b/app/views/admin/plugins.html.erb
@@ -12,7 +12,7 @@
       <tbody>
       <% @plugins.each do |plugin| %>
           <tr id="plugin-<%= plugin.id %>">
-          <td class="name"><span class="name"><%= plugin.name %></span>
+          <td class="name"><span class="name"><%= plugin.name %><%= content_tag('span', 'GEM', :class => 'badge badge-gem') if plugin.gem? %></span>
               <%= content_tag('span', plugin.description, :class => 'description') unless plugin.description.blank? %>
               <%= content_tag('span', link_to(plugin.url, plugin.url), :class => 'url') unless plugin.url.blank? %>
           </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -404,13 +404,12 @@ Rails.application.routes.draw do
 
   get 'robots', :to => 'welcome#robots'
 
-  Dir.glob File.expand_path("#{Redmine::Plugin.directory}/*") do |plugin_dir|
-    file = File.join(plugin_dir, "config/routes.rb")
-    if File.exist?(file)
+  Redmine::Plugin.all.each do |plugin|
+    if file = plugin.routes
       begin
         instance_eval File.read(file)
       rescue SyntaxError, StandardError => e
-        puts "An error occurred while loading the routes definition of #{File.basename(plugin_dir)} plugin (#{file}): #{e.message}."
+        puts "An error occurred while loading the routes definition of #{File.basename(plugin.directory)} plugin (#{file}): #{e.message}."
         exit 1
       end
     end

--- a/lib/generators/redmine_plugin_gem/USAGE
+++ b/lib/generators/redmine_plugin_gem/USAGE
@@ -1,0 +1,29 @@
+Description:
+    The plugin generator creates stubs for a new Redmine plugin.
+
+Example:
+    bundle exec rails generate redmine_plugin_gem meetings
+      create  gems/meetings/app
+      create  gems/meetings/app/controllers
+      create  gems/meetings/app/helpers
+      create  gems/meetings/app/models
+      create  gems/meetings/app/views
+      create  gems/meetings/db/migrate
+      create  gems/meetings/lib/tasks
+      create  gems/meetings/assets/images
+      create  gems/meetings/assets/javascripts
+      create  gems/meetings/assets/stylesheets
+      create  gems/meetings/config/locales
+      create  gems/meetings/test
+      create  gems/meetings/test/fixtures
+      create  gems/meetings/test/unit
+      create  gems/meetings/test/functional
+      create  gems/meetings/test/integration
+      create  gems/meetings/Gemfile
+      create  gems/meetings/Rakefile
+      create  gems/meetings/README.rdoc
+      create  gems/meetings/init.rb
+      create  gems/meetings/meetings.gemspec
+      create  gems/meetings/config/routes.rb
+      create  gems/meetings/config/locales/en.yml
+      create  gems/meetings/test/test_helper.rb

--- a/lib/generators/redmine_plugin_gem/redmine_plugin_gem_generator.rb
+++ b/lib/generators/redmine_plugin_gem/redmine_plugin_gem_generator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Redmine - project management software
+# Copyright (C) 2006-2023  Jean-Philippe Lang
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+class RedminePluginGemGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("../templates", __FILE__)
+
+  attr_reader :gem_path, :plugin_name, :plugin_pretty_name
+
+  def initialize(*args)
+    super
+    @plugin_name = file_name.underscore
+    @plugin_pretty_name = plugin_name.titleize
+    @gem_path = Rails.root.join('gems', plugin_name)
+  end
+
+  def copy_templates
+    empty_directory "#{gem_path}/app"
+    empty_directory "#{gem_path}/app/controllers"
+    empty_directory "#{gem_path}/app/helpers"
+    empty_directory "#{gem_path}/app/models"
+    empty_directory "#{gem_path}/app/views"
+    empty_directory "#{gem_path}/db/migrate"
+    empty_directory "#{gem_path}/lib/tasks"
+    empty_directory "#{gem_path}/assets/images"
+    empty_directory "#{gem_path}/assets/javascripts"
+    empty_directory "#{gem_path}/assets/stylesheets"
+    empty_directory "#{gem_path}/config/locales"
+    empty_directory "#{gem_path}/test"
+    empty_directory "#{gem_path}/test/fixtures"
+    empty_directory "#{gem_path}/test/unit"
+    empty_directory "#{gem_path}/test/functional"
+    empty_directory "#{gem_path}/test/integration"
+    empty_directory "#{gem_path}/test/system"
+
+    template 'README.rdoc',    "#{gem_path}/README.rdoc"
+    template 'Gemfile.erb',    "#{gem_path}/Gemfile"
+    template 'Rakefile',    "#{gem_path}/Rakefile"
+    template 'init.rb.erb',   "#{gem_path}/init.rb"
+    template 'routes.rb',    "#{gem_path}/config/routes.rb"
+    template 'en_rails_i18n.yml',    "#{gem_path}/config/locales/en.yml"
+    template 'test_helper.rb.erb',    "#{gem_path}/test/test_helper.rb"
+    template 'gemspec.erb', "#{gem_path}/#{plugin_name}.gemspec"
+  end
+end

--- a/lib/generators/redmine_plugin_gem/templates/Gemfile.erb
+++ b/lib/generators/redmine_plugin_gem/templates/Gemfile.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in <%= plugin_name %>.gemspec
+gemspec
+

--- a/lib/generators/redmine_plugin_gem/templates/README.rdoc
+++ b/lib/generators/redmine_plugin_gem/templates/README.rdoc
@@ -1,0 +1,3 @@
+= <%= file_name %>
+
+Description goes here

--- a/lib/generators/redmine_plugin_gem/templates/Rakefile
+++ b/lib/generators/redmine_plugin_gem/templates/Rakefile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+task default: []

--- a/lib/generators/redmine_plugin_gem/templates/en_rails_i18n.yml
+++ b/lib/generators/redmine_plugin_gem/templates/en_rails_i18n.yml
@@ -1,0 +1,3 @@
+# English strings go here for Rails i18n
+en:
+  # my_label: "My label"

--- a/lib/generators/redmine_plugin_gem/templates/gemspec.erb
+++ b/lib/generators/redmine_plugin_gem/templates/gemspec.erb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+
+  # Do not use constants or variables from the gem's own code in this block, as is normally
+  # done with gems. (e.g. Foo::VERSION)
+  # Specify the version of redmine or dependencies between plugins in the init.rb file.
+
+  spec.name = "<%= plugin_name %>"
+  spec.version = "0.0.1"
+  spec.authors = ["johndoe"]
+  spec.email = ["johndoe@example.org"]
+
+  spec.summary = "<%= plugin_pretty_name %> plugin"
+  spec.description = "This is a plugin for Redmine"
+  spec.homepage = "https://example.org"
+  spec.required_ruby_version = ">= 2.7.0"
+
+  spec.metadata["author_url"] = spec.homepage
+  spec.files = Dir["{app,lib,config,assets,db}/**/*", "init.rb", "Gemfile", "README.rdoc"]
+
+  # DO NOT DELETE this attribute
+  spec.metadata["redmine_plugin_id"] = "<%= plugin_name %>"
+end

--- a/lib/generators/redmine_plugin_gem/templates/init.rb.erb
+++ b/lib/generators/redmine_plugin_gem/templates/init.rb.erb
@@ -1,0 +1,13 @@
+Redmine::Plugin.register :<%= plugin_name %> do
+  # For gemmed plugins, the attributes of the plugin are described in the gemspec.
+  # The correspondence between plugin attributes and gemspec is as follows
+
+  # plugin name        => gemspec summary
+  # plugin author      => gemspec authors
+  # plugin description => gemspec description
+  # plugin version     => gemspec version
+  # plugin url         => gemspec homepage
+  # plugin author_url  => gemspec metadata['author_url']
+
+  # Other attributes should continue to be added to this block
+end

--- a/lib/generators/redmine_plugin_gem/templates/routes.rb
+++ b/lib/generators/redmine_plugin_gem/templates/routes.rb
@@ -1,0 +1,2 @@
+# Plugin's routes
+# See: http://guides.rubyonrails.org/routing.html

--- a/lib/generators/redmine_plugin_gem/templates/test_helper.rb.erb
+++ b/lib/generators/redmine_plugin_gem/templates/test_helper.rb.erb
@@ -1,0 +1,2 @@
+# Load the Redmine helper
+require_relative '../../../test/test_helper'

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1524,7 +1524,11 @@ td.gantt_selected_column .gantt_hdr,.gantt_selected_column_container {
 .badge-issues-count {
   background: #EEEEEE;
 }
-
+.badge-gem {
+  color: #E9573F;
+  border: 1px solid #E9573F;
+  margin-left: 0.5rem;
+}
 /***** Tooltips *****/
 .ui-tooltip {
   background: #000;

--- a/test/fixtures/gem_plugins/.gitignore
+++ b/test/fixtures/gem_plugins/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/test/fixtures/gem_plugins/Gemfile
+++ b/test/fixtures/gem_plugins/Gemfile
@@ -1,0 +1,7 @@
+original_gemfile = File.join(File.dirname(__FILE__), "../../../Gemfile")
+
+eval_gemfile original_gemfile
+
+group :redmine_extension do
+  gem 'baz', :path => './baz'
+end

--- a/test/fixtures/gem_plugins/baz/Gemfile
+++ b/test/fixtures/gem_plugins/baz/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in baz_plugin.gemspec
+gemspec

--- a/test/fixtures/gem_plugins/baz/baz.gemspec
+++ b/test/fixtures/gem_plugins/baz/baz.gemspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "baz"
+  spec.version = "0.0.1"
+  spec.authors = ['johndoe', 'janedoe']
+  spec.email = ['johndoe@example.org']
+
+  spec.summary = "Baz Plugin"
+  spec.description = "This is a gemified plugin for Redmine"
+  spec.homepage = "https://example.org/plugins/baz"
+
+  spec.required_ruby_version = ">= 2.7.0"
+
+  spec.metadata['allowed_push_host'] = "https://example.org"
+
+  spec.metadata['redmine_plugin_id'] = "baz_plugin"
+  spec.metadata['rubygems_mfa_required'] = "true"
+  spec.files = Dir["{app,lib,config,assets,db}/**/*", "init.rb", "Gemfile", "README.rdoc"]
+end

--- a/test/fixtures/gem_plugins/baz/init.rb
+++ b/test/fixtures/gem_plugins/baz/init.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Redmine::Plugin.register :baz_plugin do
+  name "This name should be overwritten with gemspec 'summary'"
+  author_url "https://example.org/this_url_should_not_be_overwritten_with_gemspec"
+end

--- a/test/fixtures/gem_plugins/baz/lib/baz_plugin.rb
+++ b/test/fixtures/gem_plugins/baz/lib/baz_plugin.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module BazPlugin
+  class Error < StandardError; end
+end

--- a/test/fixtures/plugins/qux_plugin/init.rb
+++ b/test/fixtures/plugins/qux_plugin/init.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Redmine::Plugin.register :baz_plugin do
+  name "This name should be overwritten with gemspec 'summary'"
+end


### PR DESCRIPTION
Redmine 5.0以降(Rails6.1以降)に対応したパッチを作成しました。

プラグインを gem にすることで、必要なプラグインを Gemfile.extension に記載し、bundle install を行うだけで全てのプラグインを一括インストールすることができるようになります(たとえばDocker環境でDockerfileにプラグイン導入スクリプトを書き込んだりする作業が不要になります)。

一方で、従来の plugins/ 以下に配置されたプラグインもそのまま動きます。ここでは、従来のプラグインを “filesystem plugin”、gem化されたプラグインを “gem plugin” とよびます。

“gem plugin” と同じIDの “filesystem plugin” がインストール済の場合、”filesystem plugin” が優先されます。

“gem plugin” をインストールするためには、Gemfile.extension にgem名を記載します。なお、Gemfile.extension が Gemfile.plugin という名称でないのは、将来、テーマもgem化することを想定しているためです。

“gem plugin”では、プラグインの情報は init.rb と gemspecファイルに分かれることになります。プラグイン名、作者などの基本的な情報はgemspecのものが優先されます。メニュー、設定の追加などRedmine固有の情報は従来どおりinit.rbに記載します。

試行として、redmine-view-customize をgem化してみました。問題なく動いています([https://github.com/tohosaku/redmine-view-customize/tree/rubygems](https://github.com/tohosaku/redmine-view-customize/tree/rubygems))。

gem名称、RedmineプラグインのID、gitリポジトリ名、libディレクトリ以下のクラス名は、それぞれ一致させる必要はありません。View Customizeプラグインの例は以下の通りです。もちろん全てを一致させることもできます。

| gem name | redmine-view-cusomize |
| --- | --- |
| gitub repository name | redmine-view-cusomize |
| Redmine::Plugin#id | view_customize |
| lib name | redmine_view_cusomize.rb |

一方で異なるgem名で同一のplugin id のpluginを登録しようとするとエラーが発生します。

## 従来との相違点

“filesystem plugin” では、プラグインのGemfileにgemを記載しておくことで、Redmine本体にgemを追加できました(Gemfile 116〜119行目による)。これは、Redmineが各プラグインのGemfileを読み込みredmine自身の依存gemとしてrequireしていたからです。gem pluginでは、それぞれのgemspecに add_dependency を記載する必要があります。依存物は、プラグインを Redmine に登録するタイミングで自動的にロードされます。

## 新規プラグインの作成

bin/rails g redmine_plugin_gem で、”gem plugin” を生成します。

gemを作成する場合は通常`bundle gem`コマンドで雛形を作ることが多いのですが、通常のgemと”gem plugin”ではgemspecの記載方法に後述の違いがあるため、bin/rails g で雛形を作ることを推奨します。

## “gem plugin” のgemspecに関する注意点

- gemspecファイル内で、gemで定義される変数、定数などを使用しないでください。gemspecはrails初期化完了前に評価されます。redmineプラグインの変数、定数はrails起動後にオートローダーによって管理されることを想定しているので、初期化の時点で使用するとエラーになります。
- redmineプラグイン同士の依存関係は gemspec に書かず、init.rb の redmine_required_plugin で指定してください。
- gemspecのメタデータとして `spec.metadata["redmine_plugin_id"] = "プラグインID”` が必須です。
- 従来、init.rbに記載ていた以下の属性は、gemspecの対応する属性によって上書きされます。

| init.rbの属性 | gemspec属性 |
| --- | --- |
| name | summary |
| author | authors |
| description | description |
| version | version |
| url  | homepage |
| author_url | metadata['author_url'] |

## UIの変更点

プラグインのリストで”gem plugin” かどうかを区別することができるようにしました。